### PR TITLE
The QR Code Fountain Scanner doesn't work

### DIFF
--- a/src/components/DataTransferComponents/UniversalFountainScanner.tsx
+++ b/src/components/DataTransferComponents/UniversalFountainScanner.tsx
@@ -150,7 +150,11 @@ const UniversalFountainScanner = ({
         try {
           // Convert base64 back to binary and create block
           const binaryData = toUint8Array(packet.data);
-          const block = binaryToBlock(binaryData);
+          const block = {
+            k: packet.k,
+            indices: packet.indices,
+            data: binaryData,
+          };
 
           // Add block to decoder
           addDebugMsg(`🔧 Adding block to decoder...`);


### PR DESCRIPTION
The fountain code scanner was calling binaryToBlock with only the raw binary data, discarding the k and indices fields from each scanned packet. These fields are required by the Luby Transform decoder to know which source blocks were XOR'd together to create each encoded packet — without them, the decoder can never solve the system of equations needed to reconstruct the original data.

This caused QR data transfer to always stall at 99.0% for all users on all devices.
Fix: Pass k and indices from the packet alongside the binary data when constructing each block before feeding it to the decoder.